### PR TITLE
修复无法识别只包含一个站点地图的站点地图索引的问题

### DIFF
--- a/__tests__/data/sitemap-index-single.example.xml
+++ b/__tests__/data/sitemap-index-single.example.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+    <sitemap>
+
+        <loc>http://www.example.com/sitemap1.xml.gz</loc>
+
+        <lastmod>2004-10-01T18:23:17+00:00</lastmod>
+
+    </sitemap>
+
+</sitemapindex>

--- a/__tests__/sitemapindex-handler.test.ts
+++ b/__tests__/sitemapindex-handler.test.ts
@@ -36,4 +36,26 @@ describe('sitemapindex-handler test cases', () => {
       dayjs('2005-01-01').toDate()
     );
   });
+
+  test('sitemap index with single sitemap', async () => {
+    indexContent = readFileSync(
+      resolve(__dirname, './data/sitemap-index-single.example.xml')
+    ).toString();
+
+    const sitemapIndexHandler = new SitemapIndexHandler();
+    const sitemapIndex = sitemapIndexHandler.handleSitemapIndex(
+      await XmlParser.parse(indexContent)
+    );
+
+    expect(sitemapIndex).toBeTruthy();
+    expect(sitemapIndex.sites).toBeTruthy();
+    expect(sitemapIndex.sites.length).toEqual(1);
+
+    expect(sitemapIndex.sites[0].loc.href).toStrictEqual(
+      'http://www.example.com/sitemap1.xml.gz'
+    );
+    expect(sitemapIndex.sites[0].lastmod).toStrictEqual(
+      dayjs('2004-10-01T18:23:17+00:00').toDate()
+    );
+  });
 });

--- a/src/xml-parser.ts
+++ b/src/xml-parser.ts
@@ -2,7 +2,8 @@ import {XMLParser} from 'fast-xml-parser';
 
 const parseOptions = {
   ignoreAttributes: false,
-  attributeNamePrefix: '@'
+  attributeNamePrefix: '@',
+  isArray: (tagName: string) => tagName === 'sitemap'
 };
 
 const XmlParser = {


### PR DESCRIPTION
## 问题

无法识别只包含一个站点地图的站点地图索引，例如

```xml
<?xml version="1.0" encoding="UTF-8"?>
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

    <sitemap>

        <loc>http://www.example.com/sitemap1.xml.gz</loc>

        <lastmod>2004-10-01T18:23:17+00:00</lastmod>

    </sitemap>

</sitemapindex>
```

## 原因

fast-xml-parser [默认](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/v4/2.XMLparseOptions.md#isarray) 将单个标签解析为 Object 而不是 Array，但是代码中未考虑到该情况
https://github.com/bojieyang/indexnow-action/blob/cf64cd81e78058a0167e3093c23678e9a2ef9eeb/src/sitemapindex-handler.ts#L52

解析出的 `sitemaps` Object 不包含 `length` 属性。

## 解决方式

根据这篇 [回答](https://stackoverflow.com/a/75813710) 和 fast-xml-parser 的 [文档](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/v4/2.XMLparseOptions.md#isarray) 在 `parseOptions` 中添加 `isArray: (tagName: string) => tagName === 'sitemap'`，从而使单个 sitemap 解析为 Array。