### PR TITLE
chore: migrate from Node 20 to Node 24

### DIFF
--- a/.github/workflows/basic-validation.yml
+++ b/.github/workflows/basic-validation.yml
@@ -16,4 +16,4 @@ jobs:
     name: Basic validation
     uses: actions/reusable-workflows/.github/workflows/basic-validation.yml@main
     with:
-      node-version: '20.x'
+      node-version: '24.x'

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set Node.js 20
+      - name: Set Node.js 24
         uses: actions/setup-node@v4.4.0
         with:
-          node-version: '20.x'
+          node-version: '24.x'
 
       - name: Install dependencies
         run: npm ci

--- a/action.yml
+++ b/action.yml
@@ -69,5 +69,5 @@ inputs:
     required: false
     default: 'true'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Automatically submit URLs through the IndexNow protocol.",
   "main": "index.js",
   "engines": {
-    "node": ">=20.0"
+    "node": ">=24.0"
   },
   "scripts": {
     "lint": "eslint --config ./.eslintrc.js **/*.ts",


### PR DESCRIPTION
## Why

GitHub has [deprecated Node.js 20 for Actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Workflows using this action now emit:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: bojieyang/indexnow-action@v2.1.0.

Timeline:
- **June 16, 2026** – runners default to Node 24 (forced upgrade of `node20` actions).
- **Fall 2026** – Node 20 binary removed from runners; `using: 'node20'` will hard-fail.

## What

- `action.yml`: `using: 'node20'` → `'node24'`
- `package.json`: engines `"node": ">=20.0"` → `">=24.0"`
- `.github/workflows/basic-validation.yml`: `node-version: '20.x'` → `'24.x'`
- `.github/workflows/check-dist.yml`: `node-version: '20.x'` → `'24.x'`

## Verification

Locally on Node v24.15.0:
- `npm ci` — clean install
- `npm run build` — `dist/index.js` rebuilt **byte-identically** (no dist change needed)
- `npm test` — 66/66 tests pass across 14 suites

## Compatibility

Node 24 is incompatible with macOS 13.4 and lower, and drops ARM32 self-hosted runners. For an Actions consumer of this action on `ubuntu-latest` / `windows-latest` / `macos-latest`, this is transparent.